### PR TITLE
remove sliders

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -36,11 +36,11 @@ class Image2Video:
                 "prompt": ("STRING", {"multiline": True, "dynamicPrompts": True}),
                 # "clip": ("CLIP", ),
                 "seed": ("INT", {"default": 123, "min": 0, "max": 0xffffffffffffffff}),
-                "eta": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 15.0, "step": 0.1, "display": "slider"}),
-                "cfg_scale": ("FLOAT", {"default": 7.5, "min": 1.0, "max": 15.0, "step": 0.5, "display": "slider"}),
-                "steps": ("INT", {"default": 50, "min": 1, "max": 60, "step": 1, "display": "slider"}),
-                "frame_count": ("INT", {"default": 10, "min": 5, "max": 30, "step": 1, "display": "slider"}),
-                "fps": ("INT", {"default": 8, "min": 1, "max": 60, "step": 1, "display": "slider"}),
+                "eta": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 15.0, "step": 0.1}),
+                "cfg_scale": ("FLOAT", {"default": 7.5, "min": 1.0, "max": 15.0, "step": 0.5}),
+                "steps": ("INT", {"default": 50, "min": 1, "max": 60, "step": 1}),
+                "frame_count": ("INT", {"default": 10, "min": 5, "max": 30, "step": 1}),
+                "fps": ("INT", {"default": 8, "min": 1, "max": 60, "step": 1}),
             }
         }
 


### PR DESCRIPTION

![node](https://github.com/AIGODLIKE/ComfyUI-ToonCrafter/assets/46942135/32ca4021-c393-4069-8c05-276b67cd5159)

This PR removes the bad slider implementation lightgraph currently uses. ComfyAnon and other node authors do not use this because you cannot type in input values. the default behaviour of the inputs can also be dragged to a value instead. Maybe the planned migration to the maintained [lightgraph fork](https://github.com/daniel-lewis-ab/litegraph.js) might fix this issue in the future but for now everything should be standardized to the default input to fit better in the ecosystem. Also, please send me a discord invite if your org or individuals have one. I have been with comfyanon since the beginning (he is my best friend in the space) and I specialize in animations so I could probably help you guys out. Thanks for authoring this implementation while the comfy summit was happening!